### PR TITLE
introduce relative search window

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,37 +33,37 @@ The best variation (principal variation, PV) is shown with a thick solid line.
 More options are available to visualize a tree. For example, allowing a local chess engine for analysis, changing the depth, or using images for the boards. The shape of the tree (and the cost of generating it), is strongly affected by the alpha, beta, and depth parameters. Start at low depth, and narrow [alpha, beta] range.
 
 ```
-usage: chessgraph.py [-h] [--networkstyle {graph,tree}] [--depth DEPTH] [--alpha ALPHA] [--beta BETA] [--concurrency CONCURRENCY]
-                     [--position POSITION | --san SAN] [--source {chessdb,engine,lichess}] [--lichessdb {masters,lichess}]
-                     [--boardstyle {unicode,svg,none}] [--boardedges BOARDEDGES] [--engine ENGINE] [--enginedepth ENGINEDEPTH]
-                     [--enginemaxmoves ENGINEMAXMOVES] [--output OUTPUT] [--embed | --no-embed] [--purgecache | --no-purgecache]
+usage: chessgraph.py [-h] [--position POSITION | --san SAN] [--depth DEPTH] [--alpha ALPHA] [--beta BETA] [--relwin] [--concurrency CONCURRENCY] [--source {chessdb,lichess,engine}]
+                     [--lichessdb {masters,lichess}] [--engine ENGINE] [--enginedepth ENGINEDEPTH] [--enginemaxmoves ENGINEMAXMOVES] [--networkstyle {graph,tree}]
+                     [--boardstyle {unicode,svg,none}] [--boardedges BOARDEDGES] [--output OUTPUT] [--embed | --no-embed] [--purgecache | --no-purgecache]
 
 A utility to create a graph of moves from a specified chess position.
 
 options:
   -h, --help            show this help message and exit
-  --networkstyle {graph,tree}
-                        Selects the representation of the network as a graph (shows transpositions, compact) or a tree (simpler to follow, extended). (default: graph)
-  --depth DEPTH         Maximum depth (in plies) of a followed variation (default: 6)
-  --alpha ALPHA         Lower bound on the score of variations to be followed (for white) (default: 0)
-  --beta BETA           Lower bound on the score of variations to be followed (for black) (default: 15)
-  --concurrency CONCURRENCY
-                        Number of cores to use for work / requests. (default: 8)
   --position POSITION   FEN of the root position. (default: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1)
   --san SAN             Moves in SAN notation that lead to the root position. E.g. "1. g4". (default: None)
-  --source {chessdb,engine,lichess}
-                        Use chessdb, lichess or an engine to score and rank moves (default: chessdb)
+  --depth DEPTH         Maximum depth (in plies) of a followed variation. (default: 6)
+  --alpha ALPHA         Lower bound on the score of variations to be followed (for white). (default: 0)
+  --beta BETA           Lower bound on the score of variations to be followed (for black). (default: 15)
+  --relwin              Treat ALPHA and BETA as percentages to define the search window around the eval of the root position. (default: False)
+  --concurrency CONCURRENCY
+                        Number of cores to use for work / requests. (default: 8)
+  --source {chessdb,lichess,engine}
+                        Use chessdb, lichess or an engine to score and rank moves. (default: chessdb)
   --lichessdb {masters,lichess}
-                        Which lichess database to access, masters, or lichess players (default: masters)
+                        Which lichess database to access: masters, or lichess players. (default: masters)
+  --engine ENGINE       Name of the engine binary (with path as needed). (default: stockfish)
+  --enginedepth ENGINEDEPTH
+                        Depth of the search used by the engine in evaluation. (default: 20)
+  --enginemaxmoves ENGINEMAXMOVES
+                        Maximum number of moves (MultiPV) considered by the engine in evaluation. (default: 10)
+  --networkstyle {graph,tree}
+                        Selects the representation of the network as a graph (shows transpositions, compact) or a tree (simpler to follow, extended). (default: graph)
   --boardstyle {unicode,svg,none}
                         Which style to use to visualize a board. (default: unicode)
   --boardedges BOARDEDGES
                         Minimum number of edges needed before a board is visualized in the node. (default: 3)
-  --engine ENGINE       Name of the engine binary (with path as needed). (default: stockfish)
-  --enginedepth ENGINEDEPTH
-                        Depth of the search used by the engine in evaluation (default: 20)
-  --enginemaxmoves ENGINEMAXMOVES
-                        Maximum number of moves (MultiPV) considered by the engine in evaluation (default: 10)
   --output OUTPUT, -o OUTPUT
                         Name of the output file (image in .svg format). (default: chess.svg)
   --embed, --no-embed   If the individual svg boards should be embedded in the final .svg image. Unfortunately URLs are not preserved. (default: False)

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ The best variation (principal variation, PV) is shown with a thick solid line.
 More options are available to visualize a tree. For example, allowing a local chess engine for analysis, changing the depth, or using images for the boards. The shape of the tree (and the cost of generating it), is strongly affected by the alpha, beta, and depth parameters. Start at low depth, and narrow [alpha, beta] range.
 
 ```
-usage: chessgraph.py [-h] [--position POSITION | --san SAN] [--depth DEPTH] [--alpha ALPHA] [--beta BETA] [--relwin] [--concurrency CONCURRENCY] [--source {chessdb,lichess,engine}]
-                     [--lichessdb {masters,lichess}] [--engine ENGINE] [--enginedepth ENGINEDEPTH] [--enginemaxmoves ENGINEMAXMOVES] [--networkstyle {graph,tree}]
-                     [--boardstyle {unicode,svg,none}] [--boardedges BOARDEDGES] [--output OUTPUT] [--embed | --no-embed] [--purgecache | --no-purgecache]
+usage: chessgraph.py [-h] [--position POSITION | --san SAN] [--alpha ALPHA | --ralpha RALPHA | --salpha SALPHA] [--beta BETA | --rbeta RBETA | --sbeta SBETA] [--depth DEPTH] 
+                     [--concurrency CONCURRENCY] [--source {chessdb,lichess,engine}] [--lichessdb {masters,lichess}] [--engine ENGINE] [--enginedepth ENGINEDEPTH]
+                     [--enginemaxmoves ENGINEMAXMOVES] [--networkstyle {graph,tree}] [--boardstyle {unicode,svg,none}] [--boardedges BOARDEDGES] [--output OUTPUT] [--embed | --no-embed]
+                     [--purgecache | --no-purgecache]
 
 A utility to create a graph of moves from a specified chess position.
 
@@ -43,10 +44,13 @@ options:
   -h, --help            show this help message and exit
   --position POSITION   FEN of the root position. (default: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1)
   --san SAN             Moves in SAN notation that lead to the root position. E.g. "1. g4". (default: None)
-  --depth DEPTH         Maximum depth (in plies) of a followed variation. (default: 6)
   --alpha ALPHA         Lower bound on the score of variations to be followed (for white). (default: 0)
+  --ralpha RALPHA       Set ALPHA = EVAL * RALPHA , where EVAL is the eval of the root position. (default: None)
+  --salpha SALPHA       Set ALPHA = EVAL - SALPHA. (default: None)
   --beta BETA           Lower bound on the score of variations to be followed (for black). (default: 15)
-  --relwin              Treat ALPHA and BETA as percentages to define the search window around the eval of the root position. (default: False)
+  --rbeta RBETA         Set BETA = EVAL * RBETA. (default: None)
+  --sbeta SBETA         Set BETA = EVAL + SBETA. (default: None)
+  --depth DEPTH         Maximum depth (in plies) of a followed variation. (default: 6)
   --concurrency CONCURRENCY
                         Number of cores to use for work / requests. (default: 8)
   --source {chessdb,lichess,engine}

--- a/chessgraph.py
+++ b/chessgraph.py
@@ -9,7 +9,6 @@ import math
 import sys
 import concurrent.futures
 import multiprocessing
-import copy
 import hashlib
 import cairosvg
 import graphviz
@@ -82,6 +81,24 @@ class ChessGraph:
             return self.get_moves_lichess(epd)
         else:
             assert False
+
+    def get_bestscore_and_moves(self, board):
+        if board.is_checkmate():
+            moves = []
+            bestscore = -30000
+        elif (
+            board.is_stalemate()
+            or board.is_insufficient_material()
+            or board.can_claim_draw()
+        ):
+            moves = []
+            bestscore = 0
+        else:
+            moves = self.executorwork.submit(self.get_moves, board.epd()).result()
+            if self.source != "chessdb":
+                moves.sort(key=lambda item: item["score"], reverse=True)
+            bestscore = int(moves[0]["score"]) if moves else None
+        return bestscore, moves
 
     def get_moves_engine(self, epd):
         key = (epd, self.engine, self.enginedepth, self.enginemaxmoves)
@@ -334,8 +351,6 @@ class ChessGraph:
 
     def recurse(self, board, depth, alpha, beta, pvNode, plyFromRoot):
         nodenamefrom = self.node_name(board)
-        legalMovesCount = board.legal_moves.count()
-        epd = board.epd()
 
         # terminate recursion if visited
         if nodenamefrom in self.visited:
@@ -343,32 +358,17 @@ class ChessGraph:
         else:
             self.visited.add(nodenamefrom)
 
-        if board.is_checkmate():
-            moves = []
-            bestscore = -30000
-        elif (
-            board.is_stalemate()
-            or board.is_insufficient_material()
-            or board.can_claim_draw()
-        ):
-            moves = []
-            bestscore = 0
-        else:
-            moves = self.executorwork.submit(self.get_moves, epd).result()
-            bestscore = None
+        bestscore, moves = self.get_bestscore_and_moves(board)
 
         edgesfound = 0
         edgesdrawn = 0
         futures = []
         turn = board.turn
-        tooltip = epd + "&#010;"
+        tooltip = board.epd() + "&#010;"
 
-        # loop through the moves that are within delta of the bestmove
-        for m in sorted(moves, key=lambda item: item["score"], reverse=True):
+        # loop through the (sorted) moves that are within delta of the bestmove
+        for m in moves:
             score = int(m["score"])
-
-            if bestscore is None:
-                bestscore = score
 
             if score <= alpha:
                 break
@@ -386,14 +386,14 @@ class ChessGraph:
             if score == bestscore:
                 newDepth = depth - 1
             else:
-                newDepth = depth - int(1.5 + math.log(edgesfound) / math.log(2))
+                newDepth = depth - int(1.5 + math.log2(edgesfound))
 
             if newDepth >= 0:
                 if nodenameto not in self.visited:
                     futures.append(
                         self.executorgraph[depth].submit(
                             self.recurse,
-                            copy.deepcopy(board),
+                            board.copy(),
                             newDepth,
                             -beta,
                             -alpha,
@@ -420,7 +420,7 @@ class ChessGraph:
 
         concurrent.futures.wait(futures)
 
-        remainingMoves = legalMovesCount - edgesdrawn
+        remainingMoves = board.legal_moves.count() - edgesdrawn
         tooltip += "{} remaining {}&#010;".format(
             remainingMoves, "move" if remainingMoves == 1 else "moves"
         )
@@ -442,9 +442,23 @@ class ChessGraph:
             tooltip,
         )
 
-    def generate_graph(self, epd, alpha, beta):
+    def generate_graph(self, epd, alpha, beta, relativeWindow=False):
         # set initial board
         board = chess.Board(epd)
+
+        score, _ = self.get_bestscore_and_moves(board)
+        score = score if board.turn == chess.WHITE else -score
+
+        if relativeWindow:
+            alpha = int(alpha * score / 100)
+            beta = int(beta * score / 100)
+            if alpha > beta:
+                alpha, beta = beta, alpha
+
+        print("root position epd : ", epd)
+        print("eval              : ", score)
+        print("alpha             : ", alpha)
+        print("beta              : ", beta)
 
         if board.turn == chess.WHITE:
             initialAlpha, initialBeta = alpha, beta
@@ -462,42 +476,6 @@ if __name__ == "__main__":
         description="A utility to create a graph of moves from a specified chess position.",
     )
 
-    parser.add_argument(
-        "--networkstyle",
-        choices=["graph", "tree"],
-        type=str,
-        default="graph",
-        help="Selects the representation of the network as a graph (shows transpositions, compact) or a tree (simpler to follow, extended).",
-    )
-
-    parser.add_argument(
-        "--depth",
-        type=int,
-        default=6,
-        help="Maximum depth (in plies) of a followed variation",
-    )
-
-    parser.add_argument(
-        "--alpha",
-        type=int,
-        default=0,
-        help="Lower bound on the score of variations to be followed (for white)",
-    )
-
-    parser.add_argument(
-        "--beta",
-        type=int,
-        default=15,
-        help="Lower bound on the score of variations to be followed (for black)",
-    )
-
-    parser.add_argument(
-        "--concurrency",
-        type=int,
-        default=multiprocessing.cpu_count(),
-        help="Number of cores to use for work / requests.",
-    )
-
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--position",
@@ -511,11 +489,45 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--depth",
+        type=int,
+        default=6,
+        help="Maximum depth (in plies) of a followed variation.",
+    )
+
+    parser.add_argument(
+        "--alpha",
+        type=int,
+        default=0,
+        help="Lower bound on the score of variations to be followed (for white).",
+    )
+
+    parser.add_argument(
+        "--beta",
+        type=int,
+        default=15,
+        help="Lower bound on the score of variations to be followed (for black).",
+    )
+
+    parser.add_argument(
+        "--relwin",
+        action="store_true",
+        help="Treat ALPHA and BETA as percentages to define the search window around the eval of the root position.",
+    )
+
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=multiprocessing.cpu_count(),
+        help="Number of cores to use for work / requests.",
+    )
+
+    parser.add_argument(
         "--source",
-        choices=["chessdb", "engine", "lichess"],
+        choices=["chessdb", "lichess", "engine"],
         type=str,
         default="chessdb",
-        help="Use chessdb, lichess or an engine to score and rank moves",
+        help="Use chessdb, lichess or an engine to score and rank moves.",
     )
 
     parser.add_argument(
@@ -523,22 +535,7 @@ if __name__ == "__main__":
         choices=["masters", "lichess"],
         type=str,
         default="masters",
-        help="Which lichess database to access, masters, or lichess players",
-    )
-
-    parser.add_argument(
-        "--boardstyle",
-        choices=["unicode", "svg", "none"],
-        type=str,
-        default="unicode",
-        help="Which style to use to visualize a board.",
-    )
-
-    parser.add_argument(
-        "--boardedges",
-        type=int,
-        default=3,
-        help="Minimum number of edges needed before a board is visualized in the node.",
+        help="Which lichess database to access: masters, or lichess players.",
     )
 
     parser.add_argument(
@@ -554,14 +551,37 @@ if __name__ == "__main__":
         "--enginedepth",
         type=int,
         default=20,
-        help="Depth of the search used by the engine in evaluation",
+        help="Depth of the search used by the engine in evaluation.",
     )
 
     parser.add_argument(
         "--enginemaxmoves",
         type=int,
         default=10,
-        help="Maximum number of moves (MultiPV) considered by the engine in evaluation",
+        help="Maximum number of moves (MultiPV) considered by the engine in evaluation.",
+    )
+
+    parser.add_argument(
+        "--networkstyle",
+        choices=["graph", "tree"],
+        type=str,
+        default="graph",
+        help="Selects the representation of the network as a graph (shows transpositions, compact) or a tree (simpler to follow, extended).",
+    )
+
+    parser.add_argument(
+        "--boardstyle",
+        choices=["unicode", "svg", "none"],
+        type=str,
+        default="unicode",
+        help="Which style to use to visualize a board.",
+    )
+
+    parser.add_argument(
+        "--boardedges",
+        type=int,
+        default=3,
+        help="Minimum number of edges needed before a board is visualized in the node.",
     )
 
     parser.add_argument(
@@ -617,7 +637,7 @@ if __name__ == "__main__":
         fen = args.position
 
     # generate the content of the dotfile
-    chessgraph.generate_graph(fen, args.alpha, args.beta)
+    chessgraph.generate_graph(fen, args.alpha, args.beta, args.relwin)
 
     # store updated cache
     chessgraph.store_cache()

--- a/chessgraph.py
+++ b/chessgraph.py
@@ -460,9 +460,14 @@ class ChessGraph:
             beta = score + sbeta
 
         print("root position epd : ", epd)
+        print(
+            f"alpha             :  {alpha}{'  (alpha > eval!)' if alpha > score else ''}"
+        )
         print("eval              : ", score)
-        print("alpha             : ", alpha)
-        print("beta              : ", beta)
+        print(
+            f"beta              :  {beta}{'  (beta < eval!)' if beta < score else ''}"
+        )
+        print("depth             : ", self.depth)
 
         if board.turn == chess.WHITE:
             initialAlpha, initialBeta = alpha, beta
@@ -490,13 +495,6 @@ if __name__ == "__main__":
     group.add_argument(
         "--san",
         help='Moves in SAN notation that lead to the root position. E.g. "1. g4".',
-    )
-
-    parser.add_argument(
-        "--depth",
-        type=int,
-        default=6,
-        help="Maximum depth (in plies) of a followed variation.",
     )
 
     groupa = parser.add_mutually_exclusive_group()
@@ -533,6 +531,13 @@ if __name__ == "__main__":
         "--sbeta",
         type=int,
         help="Set BETA = EVAL + SBETA.",
+    )
+
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=6,
+        help="Maximum depth (in plies) of a followed variation.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
This PR introduces the possibility to define a search window relative to the eval of the root position. Also includes various cosmetic changes.

I believe this PR addresses https://github.com/vondele/chessgraph/issues/1.

PS: I am toying with the idea to use chessgraph to plot a daily graph for grobtrack, so there a relative search window would be very convenient.

Example outputs:
```shell
> python chessgraph.py --alpha 80 --beta 120 --relwin --depth 4 --san "1. g4 d5"
root position epd :  rnbqkbnr/ppp1pppp/8/3p4/6P1/8/PPPPPP1P/RNBQKBNR w KQkq - 0 2
eval              :  -122
alpha             :  -146
beta              :  -97
```
```shell
> python chessgraph.py --alpha 80 --beta 120 --relwin --depth 4 --san "1. e4 f5"
root position epd :  rnbqkbnr/ppppp1pp/8/5p2/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2
eval              :  161
alpha             :  128
beta              :  193
```